### PR TITLE
Add support for non-standard modes in VEC

### DIFF
--- a/drivers/gpu/drm/vc4/vc4_crtc.c
+++ b/drivers/gpu/drm/vc4/vc4_crtc.c
@@ -391,6 +391,7 @@ static void vc4_crtc_config_pv(struct drm_crtc *crtc, struct drm_encoder *encode
 		CRTC_WRITE(PV_V_CONTROL,
 			   PV_VCONTROL_CONTINUOUS |
 			   (is_dsi ? PV_VCONTROL_DSI : 0));
+		CRTC_WRITE(PV_VSYNCD_EVEN, 0);
 	}
 
 	CRTC_WRITE(PV_VERTA,

--- a/drivers/gpu/drm/vc4/vc4_vec.c
+++ b/drivers/gpu/drm/vc4/vc4_vec.c
@@ -429,15 +429,79 @@ static int vc4_vec_connector_atomic_check(struct drm_connector *conn,
 	struct drm_connector_state *new_state =
 		drm_atomic_get_new_connector_state(state, conn);
 
-	const struct vc4_vec_tv_mode *vec_mode =
-		&vc4_vec_tv_modes[new_state->tv.mode];
-
 	if (new_state->crtc) {
 		struct drm_crtc_state *crtc_state =
 			drm_atomic_get_new_crtc_state(state, new_state->crtc);
 
-		if (!drm_mode_equal(vec_mode->mode, &crtc_state->mode))
+		if (crtc_state->mode.htotal !=
+			    vc4_vec_tv_modes[new_state->tv.mode].mode->htotal ||
+		    crtc_state->mode.hdisplay % 4 != 0 ||
+		    crtc_state->mode.hsync_end -
+			    crtc_state->mode.hsync_start < 1)
 			return -EINVAL;
+
+		switch (crtc_state->mode.htotal) {
+		case 858:
+			/* 525-line mode */
+			if (crtc_state->mode.crtc_vdisplay < 1 ||
+			    crtc_state->mode.crtc_vdisplay > 253 ||
+			    crtc_state->mode.crtc_vsync_start -
+			            crtc_state->mode.crtc_vdisplay < 1 ||
+			    crtc_state->mode.crtc_vsync_end -
+			            crtc_state->mode.crtc_vsync_start != 3 ||
+			    crtc_state->mode.crtc_vtotal -
+			            crtc_state->mode.crtc_vsync_end < 4 ||
+			    crtc_state->mode.crtc_vtotal > 262)
+				return -EINVAL;
+
+			if ((crtc_state->mode.flags &
+			     DRM_MODE_FLAG_INTERLACE) &&
+			    (crtc_state->mode.vdisplay % 2 != 0 ||
+			     crtc_state->mode.vsync_start % 2 != 1 ||
+			     crtc_state->mode.vsync_end % 2 != 1 ||
+			     crtc_state->mode.vtotal % 2 != 1))
+				return -EINVAL;
+
+			/* progressive mode is hard-wired to 262 total lines */
+			if (!(crtc_state->mode.flags &
+			      DRM_MODE_FLAG_INTERLACE) &&
+			    crtc_state->mode.vtotal != 262)
+				return -EINVAL;
+
+			break;
+
+		case 864:
+			/* 625-line mode */
+			if (crtc_state->mode.crtc_vdisplay < 1 ||
+			    crtc_state->mode.crtc_vdisplay > 305 ||
+			    crtc_state->mode.crtc_vsync_start -
+			            crtc_state->mode.crtc_vdisplay < 1 ||
+			    crtc_state->mode.crtc_vsync_end -
+			            crtc_state->mode.crtc_vsync_start != 3 ||
+			    crtc_state->mode.crtc_vtotal -
+			            crtc_state->mode.crtc_vsync_end < 2 ||
+			    crtc_state->mode.crtc_vtotal > 312)
+				return -EINVAL;
+
+			if ((crtc_state->mode.flags &
+			     DRM_MODE_FLAG_INTERLACE) &&
+			    (crtc_state->mode.vdisplay % 2 != 0 ||
+			     crtc_state->mode.vsync_start % 2 != 0 ||
+			     crtc_state->mode.vsync_end % 2 != 0 ||
+			     crtc_state->mode.vtotal % 2 != 1))
+				return -EINVAL;
+
+			/* progressive mode is hard-wired to 312 total lines */
+			if (!(crtc_state->mode.flags &
+			      DRM_MODE_FLAG_INTERLACE) &&
+			    crtc_state->mode.vtotal != 312)
+				return -EINVAL;
+
+			break;
+
+		default:
+			return -EINVAL;
+		}
 
 		if (old_state->tv.mode != new_state->tv.mode)
 			crtc_state->mode_changed = true;
@@ -565,7 +629,10 @@ static void vc4_vec_encoder_enable(struct drm_encoder *encoder)
 	VEC_WRITE(VEC_CLMP0_START, 0xac);
 	VEC_WRITE(VEC_CLMP0_END, 0xec);
 	VEC_WRITE(VEC_CONFIG2,
-		  VEC_CONFIG2_UV_DIG_DIS | VEC_CONFIG2_RGB_DIG_DIS);
+		  VEC_CONFIG2_UV_DIG_DIS |
+		  VEC_CONFIG2_RGB_DIG_DIS |
+		  ((encoder->crtc->state->adjusted_mode.flags &
+		    DRM_MODE_FLAG_INTERLACE) ? 0 : VEC_CONFIG2_PROG_SCAN));
 	VEC_WRITE(VEC_CONFIG3, VEC_CONFIG3_HORIZ_LEN_STD);
 	VEC_WRITE(VEC_DAC_CONFIG, vec->variant->dac_config);
 

--- a/drivers/gpu/drm/vc4/vc4_vec.c
+++ b/drivers/gpu/drm/vc4/vc4_vec.c
@@ -251,7 +251,8 @@ enum vc4_vec_tv_mode_id {
 };
 
 struct vc4_vec_tv_mode {
-	const struct drm_display_mode *mode;
+	const struct drm_display_mode *interlaced_mode;
+	const struct drm_display_mode *progressive_mode;
 	u32 config0;
 	u32 config1;
 	u32 custom_freq;
@@ -285,61 +286,81 @@ static const struct debugfs_reg32 vec_regs[] = {
 };
 
 static const struct drm_display_mode drm_mode_480i = {
-	DRM_MODE("720x480", DRM_MODE_TYPE_DRIVER, 13500,
+	DRM_MODE("720x480i", DRM_MODE_TYPE_DRIVER, 13500,
 		 720, 720 + 14, 720 + 14 + 64, 720 + 14 + 64 + 60, 0,
 		 480, 480 + 7, 480 + 7 + 6, 525, 0,
 		 DRM_MODE_FLAG_INTERLACE)
 };
 
+static const struct drm_display_mode drm_mode_240p = {
+	DRM_MODE("720x240", DRM_MODE_TYPE_DRIVER, 13500,
+		 720, 720 + 14, 720 + 14 + 64, 720 + 14 + 64 + 60, 0,
+		 240, 240 + 3, 240 + 3 + 3, 262, 0, 0)
+};
+
 static const struct drm_display_mode drm_mode_576i = {
-	DRM_MODE("720x576", DRM_MODE_TYPE_DRIVER, 13500,
+	DRM_MODE("720x576i", DRM_MODE_TYPE_DRIVER, 13500,
 		 720, 720 + 20, 720 + 20 + 64, 720 + 20 + 64 + 60, 0,
 		 576, 576 + 4, 576 + 4 + 6, 625, 0,
 		 DRM_MODE_FLAG_INTERLACE)
 };
 
+static const struct drm_display_mode drm_mode_288p = {
+	DRM_MODE("720x288", DRM_MODE_TYPE_DRIVER, 13500,
+		 720, 720 + 20, 720 + 20 + 64, 720 + 20 + 64 + 60, 0,
+		 288, 288 + 2, 288 + 2 + 3, 312, 0, 0)
+};
+
 static const struct vc4_vec_tv_mode vc4_vec_tv_modes[] = {
 	[VC4_VEC_TV_MODE_NTSC] = {
-		.mode = &drm_mode_480i,
+		.interlaced_mode = &drm_mode_480i,
+		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_NTSC_STD | VEC_CONFIG0_PDEN,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
 	},
 	[VC4_VEC_TV_MODE_NTSC_J] = {
-		.mode = &drm_mode_480i,
+		.interlaced_mode = &drm_mode_480i,
+		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_NTSC_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
 	},
 	[VC4_VEC_TV_MODE_NTSC_443] = {
 		/* NTSC with PAL chroma frequency */
-		.mode = &drm_mode_480i,
+		.interlaced_mode = &drm_mode_480i,
+		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_NTSC_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS | VEC_CONFIG1_CUSTOM_FREQ,
 		.custom_freq = 0x2a098acb,
 	},
 	[VC4_VEC_TV_MODE_PAL] = {
-		.mode = &drm_mode_576i,
+		.interlaced_mode = &drm_mode_576i,
+		.progressive_mode = &drm_mode_288p,
 		.config0 = VEC_CONFIG0_PAL_BDGHI_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
 	},
 	[VC4_VEC_TV_MODE_PAL_M] = {
-		.mode = &drm_mode_480i,
+		.interlaced_mode = &drm_mode_480i,
+		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_PAL_M_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
 	},
 	[VC4_VEC_TV_MODE_PAL_N] = {
-		.mode = &drm_mode_576i,
+		.interlaced_mode = &drm_mode_576i,
+		.progressive_mode = &drm_mode_288p,
 		.config0 = VEC_CONFIG0_PAL_N_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
 	},
 	[VC4_VEC_TV_MODE_PAL60] = {
 		/* PAL-M with chroma frequency of regular PAL */
-		.mode = &drm_mode_480i,
+		.interlaced_mode = &drm_mode_480i,
+		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_PAL_M_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS | VEC_CONFIG1_CUSTOM_FREQ,
 		.custom_freq = 0x2a098acb,
 	},
 	[VC4_VEC_TV_MODE_SECAM] = {
-		.mode = &drm_mode_576i,
+		.interlaced_mode = &drm_mode_576i,
+		.progressive_mode = &drm_mode_288p,
 		.config0 = VEC_CONFIG0_SECAM_STD,
 		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
 		.custom_freq = 0x29c71c72,
@@ -399,16 +420,32 @@ static void vc4_vec_connector_destroy(struct drm_connector *connector)
 static int vc4_vec_connector_get_modes(struct drm_connector *connector)
 {
 	struct drm_connector_state *state = connector->state;
-	struct drm_display_mode *mode;
+	struct drm_display_mode *interlaced_mode, *progressive_mode;
 
-	mode = drm_mode_duplicate(connector->dev,
-				  vc4_vec_tv_modes[state->tv.mode].mode);
-	if (!mode) {
+	interlaced_mode = drm_mode_duplicate(
+		connector->dev,
+		vc4_vec_tv_modes[state->tv.mode].interlaced_mode);
+	progressive_mode = drm_mode_duplicate(
+		connector->dev,
+		vc4_vec_tv_modes[state->tv.mode].progressive_mode);
+	if (!interlaced_mode || !progressive_mode) {
 		DRM_ERROR("Failed to create a new display mode\n");
+		drm_mode_destroy(connector->dev, interlaced_mode);
+		drm_mode_destroy(connector->dev, progressive_mode);
 		return -ENOMEM;
 	}
 
-	drm_mode_probed_add(connector, mode);
+	if (connector->cmdline_mode.specified &&
+	    connector->cmdline_mode.refresh_specified &&
+	    !connector->cmdline_mode.interlace)
+		/* progressive mode set at boot, let's make it preferred */
+		progressive_mode->type |= DRM_MODE_TYPE_PREFERRED;
+	else
+		/* otherwise, interlaced mode is preferred */
+		interlaced_mode->type |= DRM_MODE_TYPE_PREFERRED;
+
+	drm_mode_probed_add(connector, interlaced_mode);
+	drm_mode_probed_add(connector, progressive_mode);
 
 	return 1;
 }
@@ -434,7 +471,7 @@ static int vc4_vec_connector_atomic_check(struct drm_connector *conn,
 			drm_atomic_get_new_crtc_state(state, new_state->crtc);
 
 		if (crtc_state->mode.htotal !=
-			    vc4_vec_tv_modes[new_state->tv.mode].mode->htotal ||
+			    vc4_vec_tv_modes[new_state->tv.mode].interlaced_mode->htotal ||
 		    crtc_state->mode.hdisplay % 4 != 0 ||
 		    crtc_state->mode.hsync_end -
 			    crtc_state->mode.hsync_start < 1)

--- a/drivers/gpu/drm/vc4/vc4_vec.c
+++ b/drivers/gpu/drm/vc4/vc4_vec.c
@@ -254,8 +254,7 @@ struct vc4_vec_tv_mode {
 	const struct drm_display_mode *interlaced_mode;
 	const struct drm_display_mode *progressive_mode;
 	u32 config0;
-	u32 config1;
-	u32 custom_freq;
+	u64 chroma_freq_millihz;
 };
 
 static const struct debugfs_reg32 vec_regs[] = {
@@ -316,54 +315,51 @@ static const struct vc4_vec_tv_mode vc4_vec_tv_modes[] = {
 		.interlaced_mode = &drm_mode_480i,
 		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_NTSC_STD | VEC_CONFIG0_PDEN,
-		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
+		.chroma_freq_millihz = 3579545455ull,
 	},
 	[VC4_VEC_TV_MODE_NTSC_J] = {
 		.interlaced_mode = &drm_mode_480i,
 		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_NTSC_STD,
-		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
+		.chroma_freq_millihz = 3579545455ull,
 	},
 	[VC4_VEC_TV_MODE_NTSC_443] = {
 		/* NTSC with PAL chroma frequency */
 		.interlaced_mode = &drm_mode_480i,
 		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_NTSC_STD,
-		.config1 = VEC_CONFIG1_C_CVBS_CVBS | VEC_CONFIG1_CUSTOM_FREQ,
-		.custom_freq = 0x2a098acb,
+		.chroma_freq_millihz = 4433618750ull,
 	},
 	[VC4_VEC_TV_MODE_PAL] = {
 		.interlaced_mode = &drm_mode_576i,
 		.progressive_mode = &drm_mode_288p,
 		.config0 = VEC_CONFIG0_PAL_BDGHI_STD,
-		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
+		.chroma_freq_millihz = 4433618750ull,
 	},
 	[VC4_VEC_TV_MODE_PAL_M] = {
 		.interlaced_mode = &drm_mode_480i,
 		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_PAL_M_STD,
-		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
+		.chroma_freq_millihz = 3575611888ull,
 	},
 	[VC4_VEC_TV_MODE_PAL_N] = {
 		.interlaced_mode = &drm_mode_576i,
 		.progressive_mode = &drm_mode_288p,
 		.config0 = VEC_CONFIG0_PAL_N_STD,
-		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
+		.chroma_freq_millihz = 3582056250ull,
 	},
 	[VC4_VEC_TV_MODE_PAL60] = {
 		/* PAL-M with chroma frequency of regular PAL */
 		.interlaced_mode = &drm_mode_480i,
 		.progressive_mode = &drm_mode_240p,
 		.config0 = VEC_CONFIG0_PAL_M_STD,
-		.config1 = VEC_CONFIG1_C_CVBS_CVBS | VEC_CONFIG1_CUSTOM_FREQ,
-		.custom_freq = 0x2a098acb,
+		.chroma_freq_millihz = 4433618750ull,
 	},
 	[VC4_VEC_TV_MODE_SECAM] = {
 		.interlaced_mode = &drm_mode_576i,
 		.progressive_mode = &drm_mode_288p,
 		.config0 = VEC_CONFIG0_SECAM_STD,
-		.config1 = VEC_CONFIG1_C_CVBS_CVBS,
-		.custom_freq = 0x29c71c72,
+		.chroma_freq_millihz = 4406250000ull,
 	},
 };
 
@@ -617,8 +613,12 @@ static void vc4_vec_encoder_enable(struct drm_encoder *encoder)
 {
 	struct vc4_vec_encoder *vc4_vec_encoder = to_vc4_vec_encoder(encoder);
 	struct vc4_vec *vec = vc4_vec_encoder->vec;
+	struct drm_display_mode *adjusted_mode =
+		&encoder->crtc->state->adjusted_mode;
 	unsigned int tv_mode = vec->connector->state->tv.mode;
 	int ret;
+	long eff_clk_rate;
+	u64 chroma_freq;
 
 	ret = pm_runtime_get_sync(&vec->pdev->dev);
 	if (ret < 0) {
@@ -633,7 +633,7 @@ static void vc4_vec_encoder_enable(struct drm_encoder *encoder)
 	 * The good news is, these 2 encoders cannot be enabled at the same
 	 * time, thus preventing incompatible rate requests.
 	 */
-	ret = clk_set_rate(vec->clock, 108000000);
+	ret = clk_set_rate(vec->clock, 8000 * adjusted_mode->clock);
 	if (ret) {
 		DRM_ERROR("Failed to set clock rate: %d\n", ret);
 		return;
@@ -644,6 +644,9 @@ static void vc4_vec_encoder_enable(struct drm_encoder *encoder)
 		DRM_ERROR("Failed to turn on core clock: %d\n", ret);
 		return;
 	}
+
+	eff_clk_rate = clk_get_rate(vec->clock);
+	DRM_DEBUG_DRIVER("Effective clock rate: %ld\n", eff_clk_rate);
 
 	/* Reset the different blocks */
 	VEC_WRITE(VEC_WSE_RESET, 1);
@@ -668,8 +671,8 @@ static void vc4_vec_encoder_enable(struct drm_encoder *encoder)
 	VEC_WRITE(VEC_CONFIG2,
 		  VEC_CONFIG2_UV_DIG_DIS |
 		  VEC_CONFIG2_RGB_DIG_DIS |
-		  ((encoder->crtc->state->adjusted_mode.flags &
-		    DRM_MODE_FLAG_INTERLACE) ? 0 : VEC_CONFIG2_PROG_SCAN));
+		  ((adjusted_mode->flags & DRM_MODE_FLAG_INTERLACE)
+			? 0 : VEC_CONFIG2_PROG_SCAN));
 	VEC_WRITE(VEC_CONFIG3, VEC_CONFIG3_HORIZ_LEN_STD);
 	VEC_WRITE(VEC_DAC_CONFIG, vec->variant->dac_config);
 
@@ -677,14 +680,20 @@ static void vc4_vec_encoder_enable(struct drm_encoder *encoder)
 	VEC_WRITE(VEC_MASK0, 0);
 
 	VEC_WRITE(VEC_CONFIG0, vc4_vec_tv_modes[tv_mode].config0);
-	VEC_WRITE(VEC_CONFIG1, vc4_vec_tv_modes[tv_mode].config1);
-	if (vc4_vec_tv_modes[tv_mode].custom_freq != 0) {
-		VEC_WRITE(VEC_FREQ3_2,
-			  (vc4_vec_tv_modes[tv_mode].custom_freq >> 16) &
-			  0xffff);
-		VEC_WRITE(VEC_FREQ1_0,
-			  vc4_vec_tv_modes[tv_mode].custom_freq & 0xffff);
-	}
+	VEC_WRITE(VEC_CONFIG1,
+		  VEC_CONFIG1_C_CVBS_CVBS | VEC_CONFIG1_CUSTOM_FREQ);
+
+	chroma_freq = vc4_vec_tv_modes[tv_mode].chroma_freq_millihz << 31;
+	chroma_freq += (125ull * (u64) eff_clk_rate) >> 1; /* proper rounding */
+	do_div(chroma_freq, eff_clk_rate);
+	do_div(chroma_freq, 125);
+	VEC_WRITE(VEC_FREQ3_2, (chroma_freq >> 16) & 0xffff);
+	VEC_WRITE(VEC_FREQ1_0, chroma_freq & 0xffff);
+
+	/* SECAM Db frequency */
+	chroma_freq = ((4250000000ull / 125) << 31) + eff_clk_rate / 2;
+	do_div(chroma_freq, eff_clk_rate);
+	VEC_WRITE(VEC_FCW_SECAM_B, chroma_freq);
 
 	VEC_WRITE(VEC_DAC_MISC,
 		  VEC_DAC_MISC_VID_ACT | VEC_DAC_MISC_DAC_RST_N);


### PR DESCRIPTION
This is a temporary PR so that the commits only belonging to this feature are shown - this code depends on https://github.com/raspberrypi/linux/pull/4241.

See https://github.com/raspberrypi/linux/pull/4406 for a corresponding upstream PR.